### PR TITLE
Keep the index intact when replacing the id field

### DIFF
--- a/lf-to-abstract-sql.js
+++ b/lf-to-abstract-sql.js
@@ -243,7 +243,7 @@
             });
         },
         AttrForeignKey: function(factType) {
-            var $elf = this, _fromIdx = this.input.idx, baseTable, factTypeResourceName, fieldID, fkName, fkTable, foreignTerm, linkResourceName, references, required;
+            var $elf = this, _fromIdx = this.input.idx, baseTable, factTypeResourceName, fieldID, fkName, fkTable, foreignTerm, index, linkResourceName, references, required;
             required = this.anything();
             baseTable = this._applyWithArgs("GetTable", factType[0][1]);
             foreignTerm = factType[2][1];
@@ -253,10 +253,11 @@
                 this._pred(baseTable.idField == fkName);
                 fieldID = this._applyWithArgs("GetTableFieldID", baseTable, fkName);
                 this._pred(!1 !== fieldID);
+                index = baseTable.fields[fieldID].index;
                 return baseTable.fields.splice(fieldID, 1);
             });
             references = this._applyWithArgs("GetReference", fkTable);
-            fieldID = this._applyWithArgs("AddTableField", baseTable, fkName, "ForeignKey", required, null, references);
+            fieldID = this._applyWithArgs("AddTableField", baseTable, fkName, "ForeignKey", required, index, references);
             this._applyWithArgs("AddRelationship", baseTable, factType.slice(1), fkName, references);
             factTypeResourceName = this._applyWithArgs("GetResourceName", factType);
             _.each($elf.synonymousForms[factTypeResourceName], function(synForm) {

--- a/lf-to-abstract-sql.ometajs
+++ b/lf-to-abstract-sql.ometajs
@@ -199,10 +199,12 @@ export ometa LF2AbstractSQL <: SBVRCompilerLibs {
 			// If the foreign key matches the id field then delete the current field before adding the new.
 			GetTableFieldID(baseTable, fkName):fieldID
 			?(fieldID !== false)
+			// But we keep any indexes intact
+			{baseTable.fields[fieldID].index}:index
 			{baseTable.fields.splice(fieldID, 1)}
 		)?
 		GetReference(fkTable):references
-		AddTableField(baseTable, fkName, 'ForeignKey', required, null, references):fieldID
+		AddTableField(baseTable, fkName, 'ForeignKey', required, index, references):fieldID
 		AddRelationship(baseTable, factType.slice(1), fkName, references)
 		GetResourceName(factType):factTypeResourceName
 		{

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "license": "BSD",
   "dependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "ometa-js": "^1.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is necessary to keep the primary key index for custom id fields, eg in https://github.com/resin-io/pinejs/blob/672316b7d28c040636ce6aeeca5d2cf9a4d9e57e/src/migrator/migrations.sbvr#L8-L12

Change-type: patch
Signed-off-by: Pagan Gazzard <page@resin.io>